### PR TITLE
Adopt new form elements for update notifications during site installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_install:
   - composer --version
 
 install:
+  - composer --verbose validate
   - composer --verbose install
 
 script:

--- a/build.dist.xml
+++ b/build.dist.xml
@@ -50,7 +50,8 @@
             <option name="account-mail" value="${drupal.admin.email}" />
             <param>${website.profile.name}</param>
             <!-- Disable sending of e-mails during installation. -->
-            <param>install_configure_form.update_status_module='array(FALSE,FALSE)'</param>
+            <param>install_configure_form.enable_update_status_module=NULL</param>
+            <param>install_configure_form.enable_update_status_emails=NULL</param>
         </drush>
     </target>
 

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,6 @@
         "drupal/console": "^1.0.1",
         "drupal/core": "~8.3",
         "drush/drush": "~8.0",
-        "php": ">=5.5.9",
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "drupal-composer/drupal-scaffold": "^2.2",
         "cweagans/composer-patches": "~1.0",
         "drupal/console": "~1.0",
-        "drupal/core": "~8.0",
+        "drupal/core": "~8.3@beta",
         "drush/drush": "~8.0",
         "php": ">=5.5.9"
     },


### PR DESCRIPTION
In [Issue #2691971: "Update Notifications" #title repeated for drupal 8 installation in configure site page](https://www.drupal.org/node/2691971) the form got reworked that allows to configure whether notifications should be sent about module updates during site installation. This will soon be released with Drupal 8.3.0.

This PR adopts these changes to the installer, so the builds can still run without errors on systems that have no mail transfer agent installed.