### PR TITLE
Add new version for symfony/css-selector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "pfrenssen/phpcs-pre-push": "1.0",
         "phing/phing": "~2.10",
         "phpunit/phpunit": ">=4.8.28 <5",
-        "symfony/css-selector": "~2.8|~3.0",
+        "symfony/css-selector": "~2.8|~3.0|~4.0",
         "webflo/drupal-core-require-dev": "~8.4"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "pfrenssen/phpcs-pre-push": "1.0",
         "phing/phing": "~2.10",
         "phpunit/phpunit": ">=4.8.28 <5",
-        "symfony/css-selector": "~2.8",
+        "symfony/css-selector": "~2.8|~3.0",
         "webflo/drupal-core-require-dev": "~8.4"
     },
     "conflict": {


### PR DESCRIPTION
In certain conditions the symfony/css-selector version has to be above 3.0 to have a successful composer installation.